### PR TITLE
Add manual setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ docker-compose run --rm app composer --version
 ```
 
 Replace `--version` with the command you need.
+For a detailed walkthrough of manual installation, see [docs/LOCAL_SETUP.md](docs/LOCAL_SETUP.md).
 
 ### Manual setup (without Docker)
 

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -1,0 +1,43 @@
+# Local Setup Guide
+
+This guide provides step-by-step instructions to run the SchoolManager project on your local machine without Docker.
+
+## Requirements
+
+- PHP **8.1** or higher with extensions `pdo_mysql`, `mbstring`, `xml` and `bcmath`
+- MySQL **8**
+- Node.js **18** or newer (only needed for building assets)
+- Composer **2**
+
+## Steps
+
+1. Copy everything inside the `src` directory to your working folder.
+2. Install PHP dependencies:
+   ```bash
+   composer install
+   ```
+3. Create the environment file and generate the application key:
+   ```bash
+   cp .env.example .env
+   php artisan key:generate
+   ```
+4. Edit `.env` with your database credentials.
+5. Run database migrations and seeders:
+   ```bash
+   php artisan migrate --seed
+   ```
+6. (Optional) If you plan to compile frontend assets locally:
+   ```bash
+   npm install
+   npm run dev
+   ```
+7. Start the development server:
+   ```bash
+   php artisan serve
+   ```
+
+## Troubleshooting
+
+- Ensure required PHP extensions are installed.
+- Verify MySQL connection details in `.env`.
+- For a fresh database, run `php artisan migrate:fresh --seed`.


### PR DESCRIPTION
## Summary
- document step-by-step local installation in `docs/LOCAL_SETUP.md`
- reference the new guide from the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684f2b3c299883258381deaa600f1530