### PR TITLE
Enforce auth and improve login UX

### DIFF
--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -8,11 +8,17 @@
             @csrf
             <div>
                 <label class="block mb-1">البريد الإلكتروني</label>
-                <input type="email" name="email" class="w-full border rounded px-3 py-2" required>
+                <input type="email" name="email" class="w-full border rounded px-3 py-2" value="{{ old('email') }}" required>
+                @error('email')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <div>
                 <label class="block mb-1">كلمة المرور</label>
                 <input type="password" name="password" class="w-full border rounded px-3 py-2" required>
+                @error('password')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <button type="submit" class="w-full bg-gray-800 text-white py-2 rounded">دخول</button>
         </form>

--- a/src/resources/views/auth/register.blade.php
+++ b/src/resources/views/auth/register.blade.php
@@ -9,10 +9,16 @@
             <div>
                 <label class="block mb-1">الاسم</label>
                 <input type="text" name="name" class="w-full border rounded px-3 py-2" value="{{ old('name') }}" required>
+                @error('name')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <div>
                 <label class="block mb-1">البريد الإلكتروني</label>
                 <input type="email" name="email" class="w-full border rounded px-3 py-2" value="{{ old('email') }}" required>
+                @error('email')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <div>
                 <label class="block mb-1">الدور</label>
@@ -20,10 +26,16 @@
                     <option value="student" @selected(old('role') == 'student')>طالب</option>
                     <option value="tutor" @selected(old('role') == 'tutor')>معلم</option>
                 </select>
+                @error('role')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <div>
                 <label class="block mb-1">كلمة المرور</label>
                 <input type="password" name="password" class="w-full border rounded px-3 py-2" required>
+                @error('password')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <div>
                 <label class="block mb-1">تأكيد كلمة المرور</label>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -19,9 +19,12 @@ Route::post('logout', [LoginController::class, 'logout'])->name('logout');
 Route::get('register', [RegisterController::class, 'showRegistrationForm'])->name('register');
 Route::post('register', [RegisterController::class, 'register']);
 
-Route::resource('students', StudentController::class);
-Route::resource('tutors', TutorController::class);
-Route::resource('materials', MaterialController::class);
+// Require users to be authenticated before accessing any resources
+Route::middleware('auth')->group(function () {
+    Route::resource('students', StudentController::class);
+    Route::resource('tutors', TutorController::class);
+    Route::resource('materials', MaterialController::class);
+});
 
 Route::prefix('admin')->name('admin.')->group(function () {
     Route::get('login', [AuthController::class, 'showLoginForm'])->name('login');


### PR DESCRIPTION
## Summary
- enforce authentication before accessing students, tutors and materials
- show validation errors on login and registration forms

## Testing
- `php -l src/routes/web.php`
- `php -l src/resources/views/auth/login.blade.php`
- `php -l src/resources/views/auth/register.blade.php`


------
https://chatgpt.com/codex/tasks/task_e_685685c0ca148325af58f46662dec09e