### PR TITLE
Enforce landing login view

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -10,8 +10,12 @@ use Illuminate\View\View;
 
 class LoginController extends Controller
 {
-    public function showLoginForm(): View
+    public function showLoginForm(): View|RedirectResponse
     {
+        if (Auth::check()) {
+            return redirect()->route('home');
+        }
+
         return view('auth.login');
     }
 
@@ -24,7 +28,7 @@ class LoginController extends Controller
 
         if (Auth::attempt($credentials + ['is_active' => true])) {
             $request->session()->regenerate();
-            return redirect()->intended('/');
+            return redirect()->intended(route('home'));
         }
 
         return back()->withErrors([

--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -1,18 +1,24 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="flex justify-center">
-    <div class="w-full max-w-md">
+<div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-600 to-purple-600">
+    <div class="w-full max-w-md bg-white p-8 rounded shadow-lg">
         <h1 class="mb-6 text-center text-2xl font-bold">تسجيل الدخول</h1>
-        <form method="POST" action="{{ route('login') }}" class="space-y-4 bg-white p-6 shadow rounded">
+        <form method="POST" action="{{ route('login') }}" class="space-y-4">
             @csrf
             <div>
                 <label class="block mb-1">البريد الإلكتروني</label>
-                <input type="email" name="email" class="w-full border rounded px-3 py-2" required>
+                <input type="email" name="email" class="w-full border rounded px-3 py-2" value="{{ old('email') }}" required>
+                @error('email')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <div>
                 <label class="block mb-1">كلمة المرور</label>
                 <input type="password" name="password" class="w-full border rounded px-3 py-2" required>
+                @error('password')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <button type="submit" class="w-full bg-gray-800 text-white py-2 rounded">دخول</button>
         </form>

--- a/src/resources/views/auth/register.blade.php
+++ b/src/resources/views/auth/register.blade.php
@@ -1,18 +1,24 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="flex justify-center">
-    <div class="w-full max-w-md">
+<div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-600 to-purple-600">
+    <div class="w-full max-w-md bg-white p-8 rounded shadow-lg">
         <h1 class="mb-6 text-center text-2xl font-bold">إنشاء حساب</h1>
-        <form method="POST" action="{{ route('register') }}" class="space-y-4 bg-white p-6 shadow rounded">
+        <form method="POST" action="{{ route('register') }}" class="space-y-4">
             @csrf
             <div>
                 <label class="block mb-1">الاسم</label>
                 <input type="text" name="name" class="w-full border rounded px-3 py-2" value="{{ old('name') }}" required>
+                @error('name')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <div>
                 <label class="block mb-1">البريد الإلكتروني</label>
                 <input type="email" name="email" class="w-full border rounded px-3 py-2" value="{{ old('email') }}" required>
+                @error('email')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <div>
                 <label class="block mb-1">الدور</label>
@@ -20,10 +26,16 @@
                     <option value="student" @selected(old('role') == 'student')>طالب</option>
                     <option value="tutor" @selected(old('role') == 'tutor')>معلم</option>
                 </select>
+                @error('role')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <div>
                 <label class="block mb-1">كلمة المرور</label>
                 <input type="password" name="password" class="w-full border rounded px-3 py-2" required>
+                @error('password')
+                    <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
             <div>
                 <label class="block mb-1">تأكيد كلمة المرور</label>

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -7,6 +7,7 @@
     <title>School Manager</title>
 </head>
 <body class="bg-gray-100">
+@unless (Request::routeIs('login') || Request::routeIs('register') || Request::is('/'))
 <nav class="bg-gray-800 mb-6">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex items-center justify-between h-16 text-white">
@@ -30,6 +31,7 @@
         </div>
     </div>
 </nav>
+@endunless
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     @yield('content')
 </div>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -11,7 +11,11 @@ use App\Http\Controllers\Auth\RegisterController;
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', [AdminDashboardController::class, 'publicHome'])->name('home');
+// Show the login page on the landing route
+Route::get('/', [LoginController::class, 'showLoginForm']);
+
+// Authenticated users land on the dashboard
+Route::get('/dashboard', [AdminDashboardController::class, 'publicHome'])->name('home');
 
 Route::get('login', [LoginController::class, 'showLoginForm'])->name('login');
 Route::post('login', [LoginController::class, 'login']);
@@ -19,9 +23,12 @@ Route::post('logout', [LoginController::class, 'logout'])->name('logout');
 Route::get('register', [RegisterController::class, 'showRegistrationForm'])->name('register');
 Route::post('register', [RegisterController::class, 'register']);
 
-Route::resource('students', StudentController::class);
-Route::resource('tutors', TutorController::class);
-Route::resource('materials', MaterialController::class);
+// Require users to be authenticated before accessing any resources
+Route::middleware('auth')->group(function () {
+    Route::resource('students', StudentController::class);
+    Route::resource('tutors', TutorController::class);
+    Route::resource('materials', MaterialController::class);
+});
 
 Route::prefix('admin')->name('admin.')->group(function () {
     Route::get('login', [AuthController::class, 'showLoginForm'])->name('login');


### PR DESCRIPTION
## Summary
- reroute '/' to login and add dashboard route
- redirect authenticated users away from login form
- hide navigation on login and register pages
- update login and registration views with full-screen gradient background

## Testing
- `php -l src/routes/web.php`
- `php -l src/app/Http/Controllers/Auth/LoginController.php`
- `php -l src/resources/views/auth/login.blade.php`
- `php -l src/resources/views/auth/register.blade.php`
- `php -l src/resources/views/layouts/app.blade.php`


------
https://chatgpt.com/codex/tasks/task_e_685685c0ca148325af58f46662dec09e